### PR TITLE
simple markdown support

### DIFF
--- a/ts/components/conversation/MessageBodyReadMore.tsx
+++ b/ts/components/conversation/MessageBodyReadMore.tsx
@@ -96,6 +96,7 @@ export function MessageBodyReadMore({
     <MessageBody
       bodyRanges={bodyRanges}
       disableLinks={disableLinks}
+      disableMarkdown={hasReadMore}
       direction={direction}
       i18n={i18n}
       onIncreaseTextLength={onIncreaseTextLength}


### PR DESCRIPTION
Disable: start a message with ```

Bold between `**`
Underline between `__`
Italic between `//`
Monospace between ``` ` ```
Strikethrough between `~~`
Highlighted between `==`